### PR TITLE
remove extraneous imports from File::Spec

### DIFF
--- a/bin/javapp
+++ b/bin/javapp
@@ -15,7 +15,7 @@ use Class::Load qw/load_class/;
 use File::Basename qw/fileparse basename/;
 use File::chdir;
 use File::Find qw/find/;
-use File::Spec qw/case_tolerant canonpath/;
+use File::Spec;
 use File::Temp qw/tempdir/;
 use Getopt::Long qw/GetOptions/;
 use Log::Log4perl qw/:easy/;


### PR DESCRIPTION
File::Spec does not export functions, instead they are called as class methods. The import arguments have, until now, ignored. Future versions of perl are intending to throw errors for unhandled imports like this.